### PR TITLE
Fix World View sanitization: Remove DM UI and restrict interactions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,42 +5,61 @@ import { ThemeManager } from './components/ThemeManager'
 import Sidebar from './components/Sidebar'
 import Toast from './components/Toast'
 import { useGameStore } from './store/gameStore'
+import { useWindowType } from './utils/useWindowType'
 
 /**
- * App is the root component for Hyle's Architect View (DM control panel)
+ * App is the root component for Hyle's dual-window architecture
  *
- * This component orchestrates the main UI layout and tool state management.
- * It combines the three core components (SyncManager, Sidebar, CanvasManager)
- * and provides the toolbar for tool selection and campaign management.
+ * This component renders differently based on window type:
+ * - **Architect View** (Main Window): Full DM control panel with UI and editing tools
+ * - **World View** (Player Window): Sanitized canvas-only display for projection
  *
- * **Component hierarchy:**
+ * **UI Sanitization Logic:**
+ * Uses the `useWindowType()` hook to detect window type and conditionally render
+ * DM-specific UI components. This ensures the World View shows only the game canvas
+ * without exposing editing tools, save/load controls, or the asset library.
+ *
+ * **Component hierarchy (Architect View):**
  * ```
  * App (root)
- *   ├── SyncManager (invisible, handles IPC sync)
- *   ├── Sidebar (left panel, token library)
+ *   ├── ThemeManager (invisible, syncs theme across windows)
+ *   ├── SyncManager (invisible, handles IPC state sync)
+ *   ├── Toast (notifications)
+ *   ├── Sidebar (left panel, token library) ← ARCHITECT ONLY
  *   └── Main area
  *       ├── CanvasManager (battlemap canvas)
- *       └── Toolbar (floating top-right)
+ *       └── Toolbar (floating top-right) ← ARCHITECT ONLY
  *           ├── Tool buttons (Select, Marker, Eraser)
  *           ├── Save/Load campaign buttons
  *           └── World View button
  * ```
  *
+ * **Component hierarchy (World View):**
+ * ```
+ * App (root)
+ *   ├── ThemeManager (invisible, syncs theme across windows)
+ *   ├── SyncManager (invisible, receives IPC state updates)
+ *   ├── Toast (notifications)
+ *   └── Main area
+ *       └── CanvasManager (battlemap canvas only, interaction-restricted)
+ * ```
+ *
  * **Tool state:**
- * Manages the active drawing/interaction tool and passes it to CanvasManager.
- * Tool changes affect CanvasManager behavior (pan, draw marker, draw eraser).
+ * Only managed in Architect View. Passed to CanvasManager to control drawing/interaction
+ * mode (select, marker, eraser). World View always uses select mode with limited interactions.
  *
  * **Campaign management:**
+ * Only available in Architect View:
  * - Save button: Serializes store state to .hyle ZIP file via IPC
  * - Load button: Deserializes .hyle file and updates store via IPC
  * - Both use Electron dialog API (handled by main process)
  *
- * **World View:**
- * - Creates separate projector window via IPC
- * - World Window receives read-only state updates via SyncManager
- * - DM controls from this window, players see World Window
+ * **World View creation:**
+ * "World View" button in Architect View toolbar creates the player-facing window via IPC.
+ * The World Window is a separate BrowserWindow that loads the same React app with
+ * `?type=world` query parameter for UI differentiation.
  *
- * @returns Root UI with Sidebar, CanvasManager, and toolbar
+ * @returns Root UI with conditional rendering based on window type
  *
  * @example
  * // This is the root component rendered in main.tsx:
@@ -49,9 +68,17 @@ import { useGameStore } from './store/gameStore'
  *     <App />
  *   </React.StrictMode>
  * )
+ *
+ * @see {@link file://./utils/useWindowType.ts useWindowType} for window detection
+ * @see {@link file://./components/SyncManager.tsx SyncManager} for state synchronization
+ * @see {@link file://./components/Canvas/CanvasManager.tsx CanvasManager} for interaction restrictions
  */
 function App() {
+  // Detect window type for UI sanitization
+  const { isArchitectView, isWorldView } = useWindowType();
+
   // Active tool state (controls CanvasManager behavior)
+  // Only used in Architect View; World View always uses 'select' with restricted interactions
   const [tool, setTool] = useState<'select' | 'marker' | 'eraser'>('select');
   const [color, setColor] = useState('#df4b26');
   const colorInputRef = useRef<HTMLInputElement>(null);
@@ -85,15 +112,20 @@ function App() {
 
   return (
     <div className="app-root w-full h-screen flex overflow-hidden">
+      {/* Global components (rendered in both Architect and World View) */}
       <ThemeManager />
       <SyncManager />
       <Toast />
 
-      <Sidebar />
+      {/* Sidebar: Only render in Architect View (DM's token library) */}
+      {isArchitectView && <Sidebar />}
 
       <div className="flex-1 relative h-full">
-        <CanvasManager tool={tool} color={color} />
-        {/* Toolbar */}
+        {/* CanvasManager: Rendered in both views, but with different interaction modes */}
+        <CanvasManager tool={tool} color={color} isWorldView={isWorldView} />
+
+        {/* Toolbar: Only render in Architect View (DM controls) */}
+        {isArchitectView && (
         <div className="toolbar fixed top-4 right-4 p-2 rounded shadow flex gap-2 z-50">
            <button
              className={`btn btn-tool ${tool === 'select' ? 'active' : ''}`}
@@ -178,6 +210,7 @@ function App() {
              World View
            </button>
         </div>
+        )}
       </div>
     </div>
   )

--- a/src/utils/useWindowType.ts
+++ b/src/utils/useWindowType.ts
@@ -1,0 +1,84 @@
+/**
+ * Hook for detecting the current window type in the dual-window architecture
+ *
+ * Hyle uses a dual-window pattern where the same React application renders
+ * in two different modes:
+ * - **Architect View** (Main Window): DM's control panel with full UI and editing tools
+ * - **World View** (Player Window): Sanitized display for projection/screen sharing
+ *
+ * Window type is determined by the `?type=world` URL query parameter, which is set
+ * by the main process when creating the World Window (see electron/main.ts:259).
+ *
+ * **Usage Pattern:**
+ * ```typescript
+ * const { isWorldView, isArchitectView } = useWindowType();
+ *
+ * // Conditional UI rendering
+ * {isArchitectView && <Sidebar />}
+ *
+ * // Conditional feature logic
+ * if (isWorldView) {
+ *   // Disable editing features
+ * }
+ * ```
+ *
+ * **Architecture Context:**
+ * - Main process creates World Window with `?type=world` query parameter
+ * - SyncManager uses this detection for state synchronization mode (producer/consumer)
+ * - App.tsx uses this for UI sanitization (hide DM tools in World View)
+ * - CanvasManager uses this for interaction restrictions (disable editing in World View)
+ *
+ * @returns Object with boolean flags for window type detection
+ * @returns {boolean} isWorldView - True if this is the player-facing World Window
+ * @returns {boolean} isArchitectView - True if this is the DM's Architect Window
+ *
+ * @example
+ * // Hide DM-only UI components in World View
+ * function App() {
+ *   const { isArchitectView } = useWindowType();
+ *   return (
+ *     <>
+ *       {isArchitectView && <Sidebar />}
+ *       <CanvasManager />
+ *     </>
+ *   );
+ * }
+ *
+ * @example
+ * // Disable editing features in World View
+ * function CanvasManager() {
+ *   const { isWorldView } = useWindowType();
+ *
+ *   const handleDrop = (e) => {
+ *     if (isWorldView) return; // Block file drops in World View
+ *     // ... process drop
+ *   };
+ * }
+ *
+ * @see {@link file://./src/components/SyncManager.tsx SyncManager.tsx} for state sync usage
+ * @see {@link file://./src/App.tsx App.tsx} for UI sanitization usage
+ * @see {@link file://./src/components/Canvas/CanvasManager.tsx CanvasManager.tsx} for interaction restrictions
+ * @see {@link file://../electron/main.ts electron/main.ts:243-263} for World Window creation
+ */
+export const useWindowType = () => {
+  const params = new URLSearchParams(window.location.search);
+  const isWorldView = params.get('type') === 'world';
+
+  return {
+    /**
+     * True if this is the World View (player-facing projection window)
+     * - UI should be sanitized (no DM tools)
+     * - Editing interactions should be disabled
+     * - State updates received via IPC (consumer mode)
+     */
+    isWorldView,
+
+    /**
+     * True if this is the Architect View (DM's control panel)
+     * - Full UI with toolbars, sidebar, and editing tools
+     * - All interactions enabled
+     * - State changes broadcast via IPC (producer mode)
+     */
+    isArchitectView: !isWorldView,
+  };
+};


### PR DESCRIPTION
**Problems Fixed:**
1. UI Leak: World View was displaying full DM interface (sidebar, toolbar, editing tools)
2. Interaction Leak: Players could draw, delete, calibrate, and modify game state
3. Both issues defeated the purpose of having a clean player-facing projection window

**Solution:**
Implemented URL parameter detection with conditional rendering and interaction blocking:

**Changes:**
- NEW: src/utils/useWindowType.ts
  * Reusable hook to detect window type via ?type=world URL parameter
  * Returns isWorldView and isArchitectView flags
  * Comprehensive JSDoc with usage examples

- UPDATED: src/App.tsx
  * Import and use useWindowType() hook
  * Conditionally render Sidebar (Architect View only)
  * Conditionally render Toolbar (Architect View only)
  * Pass isWorldView prop to CanvasManager
  * Updated JSDoc to document dual-mode rendering

- UPDATED: src/components/Canvas/CanvasManager.tsx
  * Add isWorldView prop to component interface
  * Block drawing tools in World View (marker/eraser)
  * Block file drops in World View (no drag-and-drop assets)
  * Block token deletion in World View (Delete/Backspace keys)
  * Block calibration mode in World View
  * Block transformation in World View (scale/rotate)
  * Block duplication in World View (Alt+drag)
  * Keep ALLOWED: pan, zoom, select/drag tokens
  * Added comprehensive JSDoc documenting restrictions

- UPDATED: ARCHITECTURE.md
  * Added "World View Sanitization Architecture" section
  * Documented detection mechanism, UI sanitization, and interaction restrictions
  * Added feature comparison table (Architect vs World View)
  * Documented design rationale and implementation patterns

- UPDATED: DECISIONS.md
  * Added Decision #13: "World View Sanitization"
  * Documented alternatives considered (separate React app, routing, IPC flags, CSS-only)
  * Explained rationale for URL parameter approach
  * Updated summary table with new decision

**Technical Details:**
- Detection: Uses existing ?type=world URL parameter (no changes to electron/main.ts)
- Pattern: Early return guards (if (isWorldView) return) for blocking interactions
- Performance: Zero IPC overhead, pure client-side conditional logic
- Maintainability: Single codebase, no code duplication

**Testing:**
- Architect View: All functionality preserved (full DM controls)
- World View: Clean canvas-only display with navigation enabled, editing blocked

**See Also:**
- ARCHITECTURE.md: World View Sanitization Architecture section
- DECISIONS.md: Decision #13
- src/utils/useWindowType.ts: Window detection hook with examples