### PR TITLE
Refactor token library and map relationship

### DIFF
--- a/src/components/AssetLibrary/CommandPalette.tsx
+++ b/src/components/AssetLibrary/CommandPalette.tsx
@@ -33,6 +33,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useGameStore } from '../../store/gameStore';
 import { fuzzySearch } from '../../utils/fuzzySearch';
 import { addLibraryTokenToMap } from '../../utils/tokenHelpers';
+import TokenMetadataEditor from './TokenMetadataEditor';
 
 interface CommandPaletteProps {
   isOpen: boolean;
@@ -43,6 +44,10 @@ const CommandPalette = ({ isOpen, onClose }: CommandPaletteProps) => {
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Metadata editor state
+  const [isMetadataEditorOpen, setIsMetadataEditorOpen] = useState(false);
+  const [editingItemId, setEditingItemId] = useState<string | null>(null);
 
   // Store selectors
   const tokenLibrary = useGameStore(state => state.campaign.tokenLibrary);
@@ -198,11 +203,29 @@ const CommandPalette = ({ isOpen, onClose }: CommandPaletteProps) => {
                     )}
                   </div>
 
-                  {/* Indicator */}
-                  <div className="text-neutral-600">
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
+                  {/* Actions */}
+                  <div className="flex items-center gap-2">
+                    {/* Edit button */}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditingItemId(item.id);
+                        setIsMetadataEditorOpen(true);
+                      }}
+                      className="p-2 hover:bg-neutral-600 rounded text-neutral-400 hover:text-white transition-colors"
+                      aria-label={`Edit ${item.name}`}
+                    >
+                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                      </svg>
+                    </button>
+
+                    {/* Select indicator */}
+                    <div className="text-neutral-600">
+                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </div>
                   </div>
                 </li>
               ))}
@@ -216,6 +239,16 @@ const CommandPalette = ({ isOpen, onClose }: CommandPaletteProps) => {
           <span>Press <kbd className="px-2 py-1 bg-neutral-700 rounded">Esc</kbd> to close</span>
         </div>
       </div>
+
+      {/* Token Metadata Editor */}
+      <TokenMetadataEditor
+        isOpen={isMetadataEditorOpen}
+        libraryItemId={editingItemId}
+        onClose={() => {
+          setIsMetadataEditorOpen(false);
+          setEditingItemId(null);
+        }}
+      />
     </div>
   );
 };

--- a/src/components/AssetLibrary/TokenMetadataEditor.tsx
+++ b/src/components/AssetLibrary/TokenMetadataEditor.tsx
@@ -1,0 +1,281 @@
+/**
+ * TokenMetadataEditor Component - Modal for editing library token metadata
+ *
+ * Allows editing all metadata properties of a library token:
+ * - Name
+ * - Category (Monsters, NPCs, Props, Custom)
+ * - Tags (for fuzzy search)
+ * - Default Scale
+ * - Default Vision Radius
+ * - Default Type (PC/NPC)
+ *
+ * Used by:
+ * - LibraryManager (edit button on token cards)
+ * - CommandPalette (edit action in search results)
+ */
+
+import { useState, useEffect } from 'react';
+import type { TokenLibraryItem } from '../../store/gameStore';
+import { useGameStore } from '../../store/gameStore';
+import { useIsMobile } from '../../hooks/useMediaQuery';
+
+interface TokenMetadataEditorProps {
+  isOpen: boolean;
+  libraryItemId: string | null;
+  onClose: () => void;
+}
+
+const TokenMetadataEditor = ({ isOpen, libraryItemId, onClose }: TokenMetadataEditorProps) => {
+  const isMobile = useIsMobile();
+
+  // Get library item and update function from store
+  const tokenLibrary = useGameStore(state => state.campaign.tokenLibrary);
+  const updateLibraryToken = useGameStore(state => state.updateLibraryToken);
+  const showToast = useGameStore(state => state.showToast);
+
+  // Find the library item
+  const libraryItem = libraryItemId
+    ? tokenLibrary.find(item => item.id === libraryItemId)
+    : null;
+
+  // Form state
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('');
+  const [tags, setTags] = useState('');
+  const [defaultScale, setDefaultScale] = useState('');
+  const [defaultVisionRadius, setDefaultVisionRadius] = useState('');
+  const [defaultType, setDefaultType] = useState<'PC' | 'NPC' | ''>('');
+
+  // Initialize form with library item data
+  useEffect(() => {
+    if (libraryItem) {
+      setName(libraryItem.name);
+      setCategory(libraryItem.category);
+      setTags(libraryItem.tags.join(', '));
+      setDefaultScale(libraryItem.defaultScale?.toString() || '');
+      setDefaultVisionRadius(libraryItem.defaultVisionRadius?.toString() || '');
+      setDefaultType(libraryItem.defaultType || '');
+    }
+  }, [libraryItem]);
+
+  const handleSave = () => {
+    if (!libraryItemId) return;
+
+    // Parse tags (comma-separated)
+    const parsedTags = tags
+      .split(',')
+      .map(tag => tag.trim())
+      .filter(tag => tag.length > 0);
+
+    // Parse numeric values
+    const parsedScale = defaultScale ? parseFloat(defaultScale) : undefined;
+    const parsedVisionRadius = defaultVisionRadius ? parseInt(defaultVisionRadius) : undefined;
+
+    // Validate
+    if (!name.trim()) {
+      showToast('Name cannot be empty', 'error');
+      return;
+    }
+
+    if (parsedScale !== undefined && (parsedScale <= 0 || isNaN(parsedScale))) {
+      showToast('Scale must be a positive number', 'error');
+      return;
+    }
+
+    if (parsedVisionRadius !== undefined && (parsedVisionRadius < 0 || isNaN(parsedVisionRadius))) {
+      showToast('Vision radius must be a non-negative number', 'error');
+      return;
+    }
+
+    // Update library item
+    updateLibraryToken(libraryItemId, {
+      name: name.trim(),
+      category: category || 'Custom',
+      tags: parsedTags,
+      defaultScale: parsedScale,
+      defaultVisionRadius: parsedVisionRadius,
+      defaultType: defaultType || undefined,
+    });
+
+    showToast(`Updated metadata for "${name.trim()}"`, 'success');
+    onClose();
+  };
+
+  if (!isOpen || !libraryItem) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className={`flex flex-col overflow-hidden shadow-2xl ${
+          isMobile
+            ? 'w-full h-full'
+            : 'max-w-2xl w-full rounded-lg'
+        }`}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          backgroundColor: 'var(--app-bg-base)',
+        }}
+      >
+        {/* Header */}
+        <div className="p-4 border-b border-neutral-700 bg-neutral-800">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-bold text-white">Edit Token Metadata</h2>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-neutral-700 rounded text-white"
+              aria-label="Close"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          {/* Preview */}
+          <div className="flex items-center gap-4 p-4 bg-neutral-800 rounded-lg">
+            <img
+              src={libraryItem.thumbnailSrc.replace('file:', 'media:')}
+              alt={libraryItem.name}
+              className="w-20 h-20 object-cover rounded"
+            />
+            <div className="flex-1">
+              <p className="text-white font-medium">{libraryItem.name}</p>
+              <p className="text-neutral-400 text-sm">{libraryItem.category}</p>
+            </div>
+          </div>
+
+          {/* Name */}
+          <div>
+            <label className="block text-white text-sm font-medium mb-2">
+              Name *
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full bg-neutral-700 text-white px-4 py-2 rounded border border-neutral-600 focus:border-blue-500 focus:outline-none"
+              placeholder="Token name"
+            />
+          </div>
+
+          {/* Category */}
+          <div>
+            <label className="block text-white text-sm font-medium mb-2">
+              Category
+            </label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full bg-neutral-700 text-white px-4 py-2 rounded border border-neutral-600 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="Monsters">Monsters</option>
+              <option value="NPCs">NPCs</option>
+              <option value="Props">Props</option>
+              <option value="Custom">Custom</option>
+            </select>
+          </div>
+
+          {/* Tags */}
+          <div>
+            <label className="block text-white text-sm font-medium mb-2">
+              Tags (comma-separated)
+            </label>
+            <input
+              type="text"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              className="w-full bg-neutral-700 text-white px-4 py-2 rounded border border-neutral-600 focus:border-blue-500 focus:outline-none"
+              placeholder="e.g., dragon, red, large"
+            />
+            <p className="text-neutral-500 text-xs mt-1">
+              Used for search. Separate tags with commas.
+            </p>
+          </div>
+
+          {/* Default Scale */}
+          <div>
+            <label className="block text-white text-sm font-medium mb-2">
+              Default Scale
+            </label>
+            <input
+              type="number"
+              step="0.1"
+              min="0.1"
+              value={defaultScale}
+              onChange={(e) => setDefaultScale(e.target.value)}
+              className="w-full bg-neutral-700 text-white px-4 py-2 rounded border border-neutral-600 focus:border-blue-500 focus:outline-none"
+              placeholder="1.0"
+            />
+            <p className="text-neutral-500 text-xs mt-1">
+              Size multiplier when placed on map (e.g., 1.0 = 1 grid square, 2.0 = 2 grid squares)
+            </p>
+          </div>
+
+          {/* Default Type */}
+          <div>
+            <label className="block text-white text-sm font-medium mb-2">
+              Default Type
+            </label>
+            <select
+              value={defaultType}
+              onChange={(e) => setDefaultType(e.target.value as 'PC' | 'NPC' | '')}
+              className="w-full bg-neutral-700 text-white px-4 py-2 rounded border border-neutral-600 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="">None</option>
+              <option value="PC">PC (Player Character)</option>
+              <option value="NPC">NPC (Non-Player Character)</option>
+            </select>
+            <p className="text-neutral-500 text-xs mt-1">
+              PC tokens emit vision in Fog of War
+            </p>
+          </div>
+
+          {/* Default Vision Radius */}
+          {defaultType === 'PC' && (
+            <div>
+              <label className="block text-white text-sm font-medium mb-2">
+                Default Vision Radius (feet)
+              </label>
+              <input
+                type="number"
+                step="5"
+                min="0"
+                value={defaultVisionRadius}
+                onChange={(e) => setDefaultVisionRadius(e.target.value)}
+                className="w-full bg-neutral-700 text-white px-4 py-2 rounded border border-neutral-600 focus:border-blue-500 focus:outline-none"
+                placeholder="60"
+              />
+              <p className="text-neutral-500 text-xs mt-1">
+                How far this token can see in feet (e.g., 60 for darkvision)
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-neutral-700 bg-neutral-800 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-neutral-700 hover:bg-neutral-600 rounded text-white font-medium"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded text-white font-medium"
+          >
+            Save Changes
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TokenMetadataEditor;

--- a/src/hooks/useTokenData.ts
+++ b/src/hooks/useTokenData.ts
@@ -1,0 +1,127 @@
+import { useMemo } from 'react';
+import { Token, TokenLibraryItem } from '../store/gameStore';
+import { useGameStore } from '../store/gameStore';
+
+/**
+ * ResolvedTokenData represents the fully resolved token data after merging
+ * instance overrides with library prototype defaults.
+ *
+ * All optional properties from Token are now required, as they've been resolved
+ * to either the instance value, library default, or system default.
+ */
+export interface ResolvedTokenData {
+  id: string;
+  x: number;
+  y: number;
+  src: string;
+  scale: number;
+  type: 'PC' | 'NPC' | undefined;
+  visionRadius: number | undefined;
+  name: string;
+  libraryItemId?: string;
+  // Metadata for tracking if values are inherited vs overridden (useful for UI)
+  _isInherited: {
+    scale: boolean;
+    type: boolean;
+    visionRadius: boolean;
+    name: boolean;
+  };
+}
+
+/**
+ * useTokenData - Hook to resolve token data by merging instance with library defaults
+ *
+ * Implements the Prototype/Instance pattern:
+ * 1. If token has libraryItemId, lookup the library item
+ * 2. For each property (scale, type, visionRadius, name):
+ *    - Use instance value if explicitly set (not undefined)
+ *    - Otherwise fall back to library default
+ *    - Otherwise fall back to system default
+ * 3. Return fully resolved token data
+ *
+ * @param token - The token instance from the map
+ * @returns Fully resolved token data with all properties populated
+ *
+ * @example
+ * const resolvedToken = useTokenData(token);
+ * // resolvedToken.scale is either token.scale or libraryItem.defaultScale or 1
+ * // resolvedToken.name is either token.name or libraryItem.name
+ */
+export function useTokenData(token: Token): ResolvedTokenData {
+  const tokenLibrary = useGameStore((state) => state.campaign.tokenLibrary);
+
+  return useMemo(() => {
+    // Find the library item if this token references one
+    const libraryItem: TokenLibraryItem | undefined = token.libraryItemId
+      ? tokenLibrary.find((item) => item.id === token.libraryItemId)
+      : undefined;
+
+    // System defaults (fallback when both instance and library don't specify)
+    const DEFAULT_SCALE = 1;
+    const DEFAULT_NAME = 'Token';
+
+    // Resolve each property using instance override > library default > system default
+    const resolvedScale = token.scale ?? libraryItem?.defaultScale ?? DEFAULT_SCALE;
+    const resolvedType = token.type ?? libraryItem?.defaultType;
+    const resolvedVisionRadius = token.visionRadius ?? libraryItem?.defaultVisionRadius;
+    const resolvedName = token.name ?? libraryItem?.name ?? DEFAULT_NAME;
+
+    return {
+      id: token.id,
+      x: token.x,
+      y: token.y,
+      src: token.src,
+      scale: resolvedScale,
+      type: resolvedType,
+      visionRadius: resolvedVisionRadius,
+      name: resolvedName,
+      libraryItemId: token.libraryItemId,
+      _isInherited: {
+        scale: token.scale === undefined && libraryItem?.defaultScale !== undefined,
+        type: token.type === undefined && libraryItem?.defaultType !== undefined,
+        visionRadius: token.visionRadius === undefined && libraryItem?.defaultVisionRadius !== undefined,
+        name: token.name === undefined && libraryItem?.name !== undefined,
+      },
+    };
+  }, [token, tokenLibrary]);
+}
+
+/**
+ * Utility function (non-hook version) for resolving token data
+ * Use this when you can't use hooks (e.g., in store actions or utilities)
+ *
+ * @param token - The token instance
+ * @param tokenLibrary - The array of library items
+ * @returns Fully resolved token data
+ */
+export function resolveTokenData(token: Token, tokenLibrary: TokenLibraryItem[]): ResolvedTokenData {
+  const libraryItem = token.libraryItemId
+    ? tokenLibrary.find((item) => item.id === token.libraryItemId)
+    : undefined;
+
+  const DEFAULT_SCALE = 1;
+  const DEFAULT_NAME = 'Token';
+
+  const resolvedScale = token.scale ?? libraryItem?.defaultScale ?? DEFAULT_SCALE;
+  const resolvedType = token.type ?? libraryItem?.defaultType;
+  const resolvedVisionRadius = token.visionRadius ?? libraryItem?.defaultVisionRadius;
+  const resolvedName = token.name ?? libraryItem?.name ?? DEFAULT_NAME;
+
+  return {
+    id: token.id,
+    x: token.x,
+    y: token.y,
+    src: token.src,
+    scale: resolvedScale,
+    type: resolvedType,
+    visionRadius: resolvedVisionRadius,
+    name: resolvedName,
+    libraryItemId: token.libraryItemId,
+    _isInherited: {
+      scale: token.scale === undefined && libraryItem?.defaultScale !== undefined,
+      type: token.type === undefined && libraryItem?.defaultType !== undefined,
+      visionRadius: token.visionRadius === undefined && libraryItem?.defaultVisionRadius !== undefined,
+      name: token.name === undefined && libraryItem?.name !== undefined,
+    },
+  };
+}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2,18 +2,45 @@ import { create } from 'zustand';
 import { rollForMessage } from '../utils/systemMessages';
 
 /**
- * Token represents a character, creature, or object on the battlemap
- * ... (same documentation as before)
+ * TokenMetadata represents the shared metadata properties between library items and map tokens
+ * This interface defines the properties that can be inherited from prototypes (library items)
+ * or overridden on instances (map tokens).
+ */
+export interface TokenMetadata {
+  name?: string;
+  type?: 'PC' | 'NPC';
+  visionRadius?: number;
+  scale?: number;
+}
+
+/**
+ * Token represents a character, creature, or object on the battlemap (Instance)
+ *
+ * Implements a Prototype/Instance pattern:
+ * - If libraryItemId is set, this token references a library item as its prototype
+ * - Properties like name, type, visionRadius, scale act as OVERRIDES when present
+ * - If a property is undefined, it should fall back to the library item's default value
+ * - Position (x, y) and src are always instance-specific
+ *
+ * @property libraryItemId - Optional reference to a TokenLibraryItem (prototype)
+ * @property x - Position X in world coordinates (instance-specific)
+ * @property y - Position Y in world coordinates (instance-specific)
+ * @property src - Image file:// URL (instance-specific or inherited)
+ * @property scale - Size multiplier override (falls back to library defaultScale)
+ * @property type - Token type override (falls back to library defaultType)
+ * @property visionRadius - Vision radius override (falls back to library defaultVisionRadius)
+ * @property name - Name override (falls back to library name)
  */
 export interface Token {
   id: string;
   x: number;
   y: number;
   src: string;
-  scale: number;
-  type?: 'PC' | 'NPC';
-  visionRadius?: number;
-  name?: string;
+  libraryItemId?: string; // Reference to library item prototype
+  scale?: number; // Override for library defaultScale
+  type?: 'PC' | 'NPC'; // Override for library defaultType
+  visionRadius?: number; // Override for library defaultVisionRadius
+  name?: string; // Override for library name
 }
 
 /**

--- a/src/utils/tokenHelpers.ts
+++ b/src/utils/tokenHelpers.ts
@@ -9,10 +9,14 @@ import type { Token, TokenLibraryItem, MapConfig } from '../store/gameStore';
 /**
  * Add a library token to the map at the center position
  *
- * @param libraryItem - Token library item to add
+ * Creates a token instance that references the library item as its prototype.
+ * The instance only stores position and libraryItemId - all other properties
+ * (scale, type, visionRadius, name) are inherited from the library item.
+ *
+ * @param libraryItem - Token library item to add (the prototype)
  * @param addToken - Store action to add token
  * @param map - Current map state
- * @returns The newly created token object
+ * @returns The newly created token instance
  */
 export function addLibraryTokenToMap(
   libraryItem: TokenLibraryItem,
@@ -24,16 +28,16 @@ export function addLibraryTokenToMap(
   const centerX = map ? map.x + (map.width * map.scale) / 2 : 500;
   const centerY = map ? map.y + (map.height * map.scale) / 2 : 500;
 
-  // Create token from library item
+  // Create token instance with reference to library item (prototype)
+  // Only store instance-specific properties (id, position, src, libraryItemId)
+  // Metadata (scale, type, visionRadius, name) will be inherited from library item
   const newToken: Token = {
     id: crypto.randomUUID(),
     x: centerX,
     y: centerY,
-    src: libraryItem.src,
-    scale: libraryItem.defaultScale || 1,
-    type: libraryItem.defaultType,
-    visionRadius: libraryItem.defaultVisionRadius,
-    name: libraryItem.name,
+    src: libraryItem.src, // Store src for faster access (could be made inherited later)
+    libraryItemId: libraryItem.id, // Reference to prototype
+    // scale, type, visionRadius, name are NOT set - they inherit from library item
   };
 
   addToken(newToken);


### PR DESCRIPTION
This refactors the relationship between Token Library (asset definitions) and Map Tokens (active instances) from a "detached copy" model to a proper prototype/instance pattern with property inheritance.

Changes:
- Token Interface: Added `libraryItemId` to reference library prototypes Made scale, type, visionRadius, name optional (can inherit from library)

- TokenMetadata Interface: Shared interface for inheritable properties between library items and map tokens

- Data Resolution Layer: Created `useTokenData` hook and `resolveTokenData` utility to merge instance overrides with library defaults at runtime

- Token Creation: Updated drag-and-drop and programmatic token creation to store library reference instead of copying all metadata

- Canvas Rendering: Updated CanvasManager to resolve token data before rendering, ensuring inherited properties are properly displayed

- UI Components:
  - TokenMetadataEditor: New modal for editing library token metadata
  - LibraryManager: Added edit button to token cards
  - CommandPalette: Added edit button to search results

- Store Actions: Verified `updateLibraryToken` properly triggers re-renders

Benefits:
- Global editing: Changes to library tokens propagate to all instances
- Reduced data duplication: Instances only store overrides
- Consistent defaults: New instances automatically get updated defaults
- Better maintainability: Single source of truth for token properties

Verification:
When a library token's properties (e.g., vision range) are edited via the library UI or Cmd+P search, all map tokens referencing that library item will immediately update to reflect the new values (unless they have explicit overrides).