### PR TITLE
Add Agentation dev toolbar and skill config

### DIFF
--- a/.agents/skills/agentation/SKILL.md
+++ b/.agents/skills/agentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentation
-description: Add Agentation visual feedback toolbar to a Next.js project
+description: Add Agentation visual feedback toolbar to a Vite/React or Next.js project
 ---
 
 # Agentation Setup
@@ -18,10 +18,20 @@ Set up the Agentation annotation toolbar in this project.
    - If found, report that Agentation is already set up and exit
 
 3. **Detect framework**
+   - Vite/React: has `vite.config.ts` or `vite.config.js`
    - Next.js App Router: has `app/layout.tsx` or `app/layout.js`
    - Next.js Pages Router: has `pages/_app.tsx` or `pages/_app.js`
 
 4. **Add the component**
+
+   For Vite/React, add to the root App component (typically `src/App.tsx`):
+
+   ```tsx
+   import { Agentation } from 'agentation';
+
+   // Add inside the component's return, after main content:
+   {import.meta.env.DEV && <Agentation />}
+   ```
 
    For Next.js App Router, add to the root layout:
 
@@ -29,9 +39,7 @@ Set up the Agentation annotation toolbar in this project.
    import { Agentation } from 'agentation';
 
    // Add inside the body, after children:
-   {
-     process.env.NODE_ENV === 'development' && <Agentation />;
-   }
+   {process.env.NODE_ENV === 'development' && <Agentation />}
    ```
 
    For Next.js Pages Router, add to \_app:
@@ -40,9 +48,7 @@ Set up the Agentation annotation toolbar in this project.
    import { Agentation } from 'agentation';
 
    // Add after Component:
-   {
-     process.env.NODE_ENV === 'development' && <Agentation />;
-   }
+   {process.env.NODE_ENV === 'development' && <Agentation />}
    ```
 
 5. **Confirm component setup**
@@ -78,7 +84,7 @@ Set up the Agentation annotation toolbar in this project.
 
 ## Notes
 
-- The `NODE_ENV` check ensures Agentation only loads in development
+- The environment check (`import.meta.env.DEV` for Vite or `process.env.NODE_ENV === 'development'` for Next.js) ensures Agentation only loads in development
 - Agentation requires React 18
 - The MCP server auto-starts when Claude Code launches (uses npx, no global install needed)
 - Port 4747 is used by default for the HTTP server

--- a/.agents/skills/agentation/SKILL.md
+++ b/.agents/skills/agentation/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: agentation
+description: Add Agentation visual feedback toolbar to a Next.js project
+---
+
+# Agentation Setup
+
+Set up the Agentation annotation toolbar in this project.
+
+## Steps
+
+1. **Check if already installed**
+   - Look for `agentation` in package.json dependencies
+   - If not found, run `npm install agentation` (or pnpm/yarn based on lockfile)
+
+2. **Check if already configured**
+   - Search for `<Agentation` or `import { Agentation }` in src/ or app/
+   - If found, report that Agentation is already set up and exit
+
+3. **Detect framework**
+   - Next.js App Router: has `app/layout.tsx` or `app/layout.js`
+   - Next.js Pages Router: has `pages/_app.tsx` or `pages/_app.js`
+
+4. **Add the component**
+
+   For Next.js App Router, add to the root layout:
+
+   ```tsx
+   import { Agentation } from 'agentation';
+
+   // Add inside the body, after children:
+   {
+     process.env.NODE_ENV === 'development' && <Agentation />;
+   }
+   ```
+
+   For Next.js Pages Router, add to \_app:
+
+   ```tsx
+   import { Agentation } from 'agentation';
+
+   // Add after Component:
+   {
+     process.env.NODE_ENV === 'development' && <Agentation />;
+   }
+   ```
+
+5. **Confirm component setup**
+   - Tell the user the Agentation toolbar component is configured
+
+6. **Check if MCP server already configured**
+   - Read `~/.claude/claude_code_config.json` if it exists
+   - Check if `mcpServers.agentation` entry exists
+   - If yes, skip to final confirmation step
+
+7. **Configure Claude Code MCP server**
+   - Create `~/.claude/` directory if it doesn't exist
+   - Read existing `claude_code_config.json` if present (preserve other MCP servers)
+   - Add or merge the `mcpServers.agentation` entry:
+     ```json
+     {
+       "mcpServers": {
+         "agentation": {
+           "command": "npx",
+           "args": ["agentation-mcp", "server"]
+         }
+       }
+     }
+     ```
+   - Write updated config back to file
+
+8. **Confirm full setup**
+   - Tell the user both components are set up:
+     - React component for the toolbar (`<Agentation />`)
+     - MCP server configured to auto-start with Claude Code
+   - Tell user to restart Claude Code to load the MCP server
+   - Explain that annotations will now sync to Claude automatically
+
+## Notes
+
+- The `NODE_ENV` check ensures Agentation only loads in development
+- Agentation requires React 18
+- The MCP server auto-starts when Claude Code launches (uses npx, no global install needed)
+- Port 4747 is used by default for the HTTP server
+- Run `npx agentation-mcp doctor` to verify setup

--- a/.agents/skills/agentation/SKILL.md
+++ b/.agents/skills/agentation/SKILL.md
@@ -30,7 +30,9 @@ Set up the Agentation annotation toolbar in this project.
    import { Agentation } from 'agentation';
 
    // Add inside the component's return, after main content:
-   {import.meta.env.DEV && <Agentation />}
+   {
+     import.meta.env.DEV && <Agentation />;
+   }
    ```
 
    For Next.js App Router, add to the root layout:
@@ -39,7 +41,9 @@ Set up the Agentation annotation toolbar in this project.
    import { Agentation } from 'agentation';
 
    // Add inside the body, after children:
-   {process.env.NODE_ENV === 'development' && <Agentation />}
+   {
+     process.env.NODE_ENV === 'development' && <Agentation />;
+   }
    ```
 
    For Next.js Pages Router, add to \_app:
@@ -48,7 +52,9 @@ Set up the Agentation annotation toolbar in this project.
    import { Agentation } from 'agentation';
 
    // Add after Component:
-   {process.env.NODE_ENV === 'development' && <Agentation />}
+   {
+     process.env.NODE_ENV === 'development' && <Agentation />;
+   }
    ```
 
 5. **Confirm component setup**

--- a/.claude/skills/agentation
+++ b/.claude/skills/agentation
@@ -1,0 +1,1 @@
+../../.agents/skills/agentation

--- a/AUTO_UPDATER.md
+++ b/AUTO_UPDATER.md
@@ -87,6 +87,7 @@ When running from source, the "Check for Updates" button will show "Development 
 ### Publishing a Release
 
 1. **Build the application:**
+
    ```bash
    npm run build
    ```
@@ -121,6 +122,7 @@ For auto-update to work on macOS in production, the app **must be code-signed an
 ```
 
 Without code signing:
+
 - macOS will block the installer
 - Auto-update will fail with signature verification errors
 
@@ -131,6 +133,7 @@ Without code signing:
 The auto-updater has comprehensive test coverage:
 
 **UpdateManager.test.tsx** - Tests for the UI component:
+
 - Rendering states (idle, checking, available, downloading, downloaded, error)
 - User interactions (check, download, install, close)
 - Event handling (update events, progress updates)
@@ -140,6 +143,7 @@ The auto-updater has comprehensive test coverage:
 - Error handling for all async operations
 
 **UpdateManagerErrorBoundary.test.tsx** - Tests for the error boundary:
+
 - Error catching and display
 - Error reset functionality
 - Console logging verification
@@ -147,6 +151,7 @@ The auto-updater has comprehensive test coverage:
 - Specific error type handling (network, IPC, signature)
 
 Run tests with:
+
 ```bash
 npm test UpdateManager
 npm test UpdateManagerErrorBoundary
@@ -157,6 +162,7 @@ npm test UpdateManagerErrorBoundary
 To test the update workflow without building:
 
 1. Create a `dev-app-update.yml` file in the project root:
+
    ```yaml
    version: 0.5.4
    files:
@@ -168,6 +174,7 @@ To test the update workflow without building:
    ```
 
 2. Set environment variable:
+
    ```bash
    export ELECTRON_UPDATER_ALLOW_PRERELEASE=true
    ```
@@ -261,6 +268,7 @@ autoUpdater.quitAndInstall() → App restarts
 ## Logs
 
 Production logs are written to:
+
 - **macOS:** `~/Library/Logs/Graphium/main.log`
 - **Windows:** `%USERPROFILE%\AppData\Roaming\Graphium\logs\main.log`
 - **Linux:** `~/.config/Graphium/logs/main.log`
@@ -270,6 +278,7 @@ All update events are logged with `[AutoUpdater]` prefix for easy filtering.
 ## Future Enhancements
 
 Potential improvements:
+
 1. **Automatic update checks** on app startup (currently manual only)
 2. **Release notes display** in UpdateManager modal
 3. **Update notifications** badge on About button when update available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Requires code signing for macOS production builds
 
 ### Technical Details
+
 - Added `electron-updater` ^6.3.9 for update management
 - Added `electron-log` ^5.2.4 for production logging
 - New components:
@@ -159,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation in `AUTO_UPDATER.md`
 
 ### Security
+
 - Signature verification (when app is code-signed)
 - HTTPS-only downloads from GitHub
 - No auto-download - user controls update installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@typescript-eslint/parser": "^7.1.1",
         "@vitejs/plugin-react": "^4.7.0",
         "@vitest/coverage-v8": "^4.0.18",
+        "agentation": "^2.2.0",
         "autoprefixer": "^10.4.22",
         "axe-core": "^4.11.0",
         "electron": "^35.7.5",
@@ -3667,6 +3668,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentation": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/agentation/-/agentation-2.2.0.tgz",
+      "integrity": "sha512-DIkXtC/XpOdAK/X1qYZMYocSjfU7EKe5bYG5DyxEr2wIuSxEVi2edSQsIWbB+k/S3yvAnnCfpuTkHh8LOvYxgQ==",
+      "dev": true,
+      "license": "PolyForm-Shield-1.0.0",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/parser": "^7.1.1",
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^4.0.18",
+    "agentation": "^2.2.0",
     "autoprefixer": "^10.4.22",
     "axe-core": "^4.11.0",
     "electron": "^35.7.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
   RiDoorOpenLine,
   RiRulerLine,
 } from '@remixicon/react';
+import { Agentation } from 'agentation';
 
 import { AboutModal } from './components/AboutModal';
 import CommandPalette from './components/AssetLibrary/CommandPalette';
@@ -423,7 +424,12 @@ function App() {
 
   // If accessing Design System Playground route, show it exclusively
   if (isDesignSystemPlayground) {
-    return <DesignSystemPlayground />;
+    return (
+      <>
+        <DesignSystemPlayground />
+        {import.meta.env.DEV && <Agentation />}
+      </>
+    );
   }
 
   // If in Architect View and on HOME screen, show the HomeScreen component
@@ -451,6 +457,7 @@ function App() {
 
         {/* Home/Splash Screen */}
         <HomeScreen onStartEditor={handleStartEditor} />
+        {import.meta.env.DEV && <Agentation />}
       </>
     );
   }
@@ -747,6 +754,7 @@ function App() {
           />
         )}
       </div>
+      {import.meta.env.DEV && <Agentation />}
     </div>
   );
 }

--- a/src/components/HomeScreen.test.tsx
+++ b/src/components/HomeScreen.test.tsx
@@ -41,7 +41,9 @@ describe('HomeScreen', () => {
     // Mock store functions
     vi.spyOn(useGameStore.getState(), 'showToast').mockImplementation(mockShowToast);
     vi.spyOn(useGameStore.getState(), 'loadCampaign').mockImplementation(mockLoadCampaign);
-    vi.spyOn(useGameStore.getState(), 'resetToNewCampaign').mockImplementation(mockResetToNewCampaign);
+    vi.spyOn(useGameStore.getState(), 'resetToNewCampaign').mockImplementation(
+      mockResetToNewCampaign,
+    );
     vi.spyOn(useGameStore.getState(), 'setGridSize').mockImplementation(mockSetGridSize);
 
     // Mock recentCampaigns to return empty by default
@@ -365,9 +367,7 @@ describe('HomeScreen', () => {
     it('should have ARIA labels on theme switcher', () => {
       render(<HomeScreen onStartEditor={mockOnStartEditor} />);
 
-      const themeSwitcher = screen.getByLabelText(
-        /Current theme: .*\. Click to cycle themes\./i
-      );
+      const themeSwitcher = screen.getByLabelText(/Current theme: .*\. Click to cycle themes\./i);
       expect(themeSwitcher).toBeInTheDocument();
     });
   });
@@ -557,8 +557,8 @@ describe('HomeScreen', () => {
       expect(screen.getByText('Download the Windows App')).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Get greater portability, offline support, and privacy with the native desktop application\./i
-        )
+          /Get greater portability, offline support, and privacy with the native desktop application\./i,
+        ),
       ).toBeInTheDocument();
     });
 
@@ -624,9 +624,7 @@ describe('HomeScreen', () => {
     it('should render theme switcher in footer', () => {
       render(<HomeScreen onStartEditor={mockOnStartEditor} />);
 
-      const themeSwitcher = screen.getByLabelText(
-        /Current theme: .*\. Click to cycle themes\./i
-      );
+      const themeSwitcher = screen.getByLabelText(/Current theme: .*\. Click to cycle themes\./i);
       expect(themeSwitcher).toBeInTheDocument();
     });
 
@@ -643,12 +641,12 @@ describe('HomeScreen', () => {
 
       // Wait for theme to load
       await waitFor(() => {
-        expect(screen.getByLabelText(/Current theme: Dark\. Click to cycle themes\./i)).toBeInTheDocument();
+        expect(
+          screen.getByLabelText(/Current theme: Dark\. Click to cycle themes\./i),
+        ).toBeInTheDocument();
       });
 
-      const themeSwitcher = screen.getByLabelText(
-        /Current theme: Dark\. Click to cycle themes\./i
-      );
+      const themeSwitcher = screen.getByLabelText(/Current theme: Dark\. Click to cycle themes\./i);
 
       // Click to cycle from dark → system
       fireEvent.click(themeSwitcher);
@@ -672,11 +670,13 @@ describe('HomeScreen', () => {
 
       // Wait for theme to load
       await waitFor(() => {
-        expect(screen.getByLabelText(/Current theme: Light\. Click to cycle themes\./i)).toBeInTheDocument();
+        expect(
+          screen.getByLabelText(/Current theme: Light\. Click to cycle themes\./i),
+        ).toBeInTheDocument();
       });
 
       const themeSwitcher = screen.getByLabelText(
-        /Current theme: Light\. Click to cycle themes\./i
+        /Current theme: Light\. Click to cycle themes\./i,
       );
 
       // Click to cycle theme
@@ -686,7 +686,7 @@ describe('HomeScreen', () => {
         expect(mockSetThemeMode).toHaveBeenCalledWith('dark');
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           '[HomeScreen] Failed to set theme:',
-          expect.any(Error)
+          expect.any(Error),
         );
       });
 
@@ -703,18 +703,14 @@ describe('HomeScreen', () => {
     it('should render lite mode toggle in footer', () => {
       render(<HomeScreen onStartEditor={mockOnStartEditor} />);
 
-      const liteToggle = screen.getByLabelText(
-        /Full Mode enabled\. Click to enable lite mode\./i
-      );
+      const liteToggle = screen.getByLabelText(/Full Mode enabled\. Click to enable lite mode\./i);
       expect(liteToggle).toBeInTheDocument();
     });
 
     it('should toggle lite mode when clicked', async () => {
       render(<HomeScreen onStartEditor={mockOnStartEditor} />);
 
-      const liteToggle = screen.getByLabelText(
-        /Full Mode enabled\. Click to enable lite mode\./i
-      );
+      const liteToggle = screen.getByLabelText(/Full Mode enabled\. Click to enable lite mode\./i);
 
       // Click to enable lite mode
       fireEvent.click(liteToggle);
@@ -725,7 +721,7 @@ describe('HomeScreen', () => {
 
       // Check aria-label updated
       const liteToggleAfter = screen.getByLabelText(
-        /Lite Mode enabled\. Click to enable full mode\./i
+        /Lite Mode enabled\. Click to enable full mode\./i,
       );
       expect(liteToggleAfter).toBeInTheDocument();
 
@@ -742,18 +738,14 @@ describe('HomeScreen', () => {
 
       render(<HomeScreen onStartEditor={mockOnStartEditor} />);
 
-      const liteToggle = screen.getByLabelText(
-        /Lite Mode enabled\. Click to enable full mode\./i
-      );
+      const liteToggle = screen.getByLabelText(/Lite Mode enabled\. Click to enable full mode\./i);
       expect(liteToggle).toBeInTheDocument();
     });
 
     it('should set data-lite-mode attribute on root element', async () => {
       render(<HomeScreen onStartEditor={mockOnStartEditor} />);
 
-      const liteToggle = screen.getByLabelText(
-        /Full Mode enabled\. Click to enable lite mode\./i
-      );
+      const liteToggle = screen.getByLabelText(/Full Mode enabled\. Click to enable lite mode\./i);
 
       // Enable lite mode
       fireEvent.click(liteToggle);

--- a/src/components/PendingErrorsIndicator.test.tsx
+++ b/src/components/PendingErrorsIndicator.test.tsx
@@ -80,7 +80,7 @@ describe('PendingErrorsIndicator', () => {
 
       const { container } = render(<PendingErrorsIndicator />);
       const element = container.firstChild as HTMLElement;
-      expect(element.className).toContain('bottom-4');
+      expect(element.className).toContain('bottom-16');
       expect(element.className).toContain('right-4');
     });
 

--- a/src/components/PendingErrorsIndicator.tsx
+++ b/src/components/PendingErrorsIndicator.tsx
@@ -151,7 +151,7 @@ function PendingErrorsIndicator({
   };
 
   const positionClasses = {
-    'bottom-right': 'bottom-4 right-4',
+    'bottom-right': import.meta.env.DEV ? 'bottom-16 right-4' : 'bottom-4 right-4',
     'bottom-left': 'bottom-4 left-4',
     'top-right': 'top-4 right-4',
     'top-left': 'top-4 left-4',

--- a/src/components/UpdateErrorFallbackUI.test.tsx
+++ b/src/components/UpdateErrorFallbackUI.test.tsx
@@ -119,7 +119,7 @@ describe('UpdateErrorFallbackUI', () => {
       expect(screen.getByText(/Firewall blocking update requests/i)).toBeInTheDocument();
       expect(screen.getByText(/Signature verification issues/i)).toBeInTheDocument();
       expect(
-        screen.getByText(/Corrupted update metadata from previous attempts/i)
+        screen.getByText(/Corrupted update metadata from previous attempts/i),
       ).toBeInTheDocument();
     });
 
@@ -212,7 +212,7 @@ describe('UpdateErrorFallbackUI', () => {
     it('should use memoized messages that remain stable', () => {
       const testErrorMessage = 'Test error';
       const { rerender } = render(
-        <UpdateErrorFallbackUI errorMessage={testErrorMessage} onReset={mockOnReset} />
+        <UpdateErrorFallbackUI errorMessage={testErrorMessage} onReset={mockOnReset} />,
       );
 
       // Get the displayed title
@@ -229,7 +229,9 @@ describe('UpdateErrorFallbackUI', () => {
       const errorMessage1 = 'Error 1';
       const errorMessage2 = 'Error 2';
 
-      const { rerender } = render(<UpdateErrorFallbackUI errorMessage={errorMessage1} onReset={mockOnReset} />);
+      const { rerender } = render(
+        <UpdateErrorFallbackUI errorMessage={errorMessage1} onReset={mockOnReset} />,
+      );
 
       const title1 = screen.getByRole('heading', { level: 2 }).textContent;
 

--- a/src/components/UpdateManager.test.tsx
+++ b/src/components/UpdateManager.test.tsx
@@ -64,9 +64,7 @@ describe('UpdateManager', () => {
 
   describe('Rendering', () => {
     it('should not render when closed', () => {
-      const { container } = render(
-        <UpdateManager isOpen={false} onClose={() => {}} />
-      );
+      const { container } = render(<UpdateManager isOpen={false} onClose={() => {}} />);
       expect(container.firstChild).toBeNull();
     });
 
@@ -176,9 +174,7 @@ describe('UpdateManager', () => {
       // The checking message uses randomized themed copy (e.g. "Divining the cosmic archives", "Consulting the Chronicle").
       // Assert on common keywords that appear in all variations.
       expect(
-        screen.getByText(
-          /Divining|Consulting|Communing|Rolling|Peering/i,
-        ),
+        screen.getByText(/Divining|Consulting|Communing|Rolling|Peering/i),
       ).toBeInTheDocument();
     });
 
@@ -223,17 +219,21 @@ describe('UpdateManager', () => {
       // The no-update message uses randomized themed copy (e.g. "Your forge burns", "You wield the cutting edge").
       // Assert on the title pattern which appears above the subtitle.
       expect(
-        screen.getByText(/forge burns|wield the cutting|Natural 20 on your version|arsenal is complete|chapter already graces/i),
+        screen.getByText(
+          /forge burns|wield the cutting|Natural 20 on your version|arsenal is complete|chapter already graces/i,
+        ),
       ).toBeInTheDocument();
     });
 
     it('should show download progress', async () => {
-      let progressCallback: ((progress: {
-        percent: number;
-        bytesPerSecond: number;
-        transferred: number;
-        total: number;
-      }) => void) | undefined;
+      let progressCallback:
+        | ((progress: {
+            percent: number;
+            bytesPerSecond: number;
+            transferred: number;
+            total: number;
+          }) => void)
+        | undefined;
 
       mockAutoUpdater.onDownloadProgress.mockImplementation((cb) => {
         progressCallback = cb;
@@ -360,9 +360,7 @@ describe('UpdateManager', () => {
     });
 
     it('should handle checkForUpdates error', async () => {
-      mockAutoUpdater.checkForUpdates.mockRejectedValue(
-        new Error('Check failed')
-      );
+      mockAutoUpdater.checkForUpdates.mockRejectedValue(new Error('Check failed'));
 
       render(<UpdateManager isOpen={true} onClose={() => {}} />);
 
@@ -377,9 +375,7 @@ describe('UpdateManager', () => {
     });
 
     it('should handle downloadUpdate error', async () => {
-      mockAutoUpdater.downloadUpdate.mockRejectedValue(
-        new Error('Download failed')
-      );
+      mockAutoUpdater.downloadUpdate.mockRejectedValue(new Error('Download failed'));
 
       let updateAvailableCallback: ((info: { version: string }) => void) | undefined;
       mockAutoUpdater.onUpdateAvailable.mockImplementation((cb) => {
@@ -445,12 +441,14 @@ describe('UpdateManager', () => {
     });
 
     it('should format bytes correctly in progress display', async () => {
-      let progressCallback: ((progress: {
-        percent: number;
-        bytesPerSecond: number;
-        transferred: number;
-        total: number;
-      }) => void) | undefined;
+      let progressCallback:
+        | ((progress: {
+            percent: number;
+            bytesPerSecond: number;
+            transferred: number;
+            total: number;
+          }) => void)
+        | undefined;
 
       mockAutoUpdater.onDownloadProgress.mockImplementation((cb) => {
         progressCallback = cb;

--- a/src/components/UpdateManagerErrorBoundary.test.tsx
+++ b/src/components/UpdateManagerErrorBoundary.test.tsx
@@ -42,7 +42,7 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <ThrowError shouldThrow={false} />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       expect(screen.getByText('UpdateManager content')).toBeInTheDocument();
@@ -52,7 +52,7 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <div>Normal content</div>
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
@@ -64,7 +64,7 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <ThrowError shouldThrow={true} />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // Should show error fallback UI
@@ -76,15 +76,12 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <ThrowError shouldThrow={true} />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // Verify console.error was called with error details
       expect(consoleErrorSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Update manager error:',
-        expect.any(Error)
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Update manager error:', expect.any(Error));
     });
 
     it('should reset error state when reset is triggered', async () => {
@@ -99,7 +96,7 @@ describe('UpdateManagerErrorBoundary', () => {
       const { rerender } = render(
         <UpdateManagerErrorBoundary>
           <DynamicChild />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // Error UI should be shown
@@ -119,7 +116,7 @@ describe('UpdateManagerErrorBoundary', () => {
         rerender(
           <UpdateManagerErrorBoundary>
             <DynamicChild />
-          </UpdateManagerErrorBoundary>
+          </UpdateManagerErrorBoundary>,
         );
 
         // Should show normal content again after state update
@@ -139,11 +136,11 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <NetworkError />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Network error detected')
+        expect.stringContaining('Network error detected'),
       );
     });
 
@@ -155,11 +152,11 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <IPCError />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('IPC communication error')
+        expect.stringContaining('IPC communication error'),
       );
     });
 
@@ -171,11 +168,11 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <SignatureError />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Signature verification error')
+        expect.stringContaining('Signature verification error'),
       );
     });
   });
@@ -185,7 +182,7 @@ describe('UpdateManagerErrorBoundary', () => {
       const { rerender } = render(
         <UpdateManagerErrorBoundary>
           <ThrowError shouldThrow={true} />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // Verify error state
@@ -195,7 +192,7 @@ describe('UpdateManagerErrorBoundary', () => {
       rerender(
         <UpdateManagerErrorBoundary>
           <div>Recovered content</div>
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // Note: Error boundary maintains error state until reset
@@ -209,14 +206,11 @@ describe('UpdateManagerErrorBoundary', () => {
       render(
         <UpdateManagerErrorBoundary>
           <ThrowError shouldThrow={true} />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // Verify component stack is logged
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Component stack:',
-        expect.any(String)
-      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Component stack:', expect.any(String));
     });
   });
 
@@ -225,7 +219,7 @@ describe('UpdateManagerErrorBoundary', () => {
       const { rerender } = render(
         <UpdateManagerErrorBoundary>
           <ThrowError shouldThrow={true} />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // First error
@@ -238,7 +232,7 @@ describe('UpdateManagerErrorBoundary', () => {
       rerender(
         <UpdateManagerErrorBoundary>
           <ThrowError shouldThrow={true} />
-        </UpdateManagerErrorBoundary>
+        </UpdateManagerErrorBoundary>,
       );
 
       // Should still show error UI


### PR DESCRIPTION
Install and integrate the Agentation development toolbar: add agentation dependency to package.json, import and render <Agentation /> in App.tsx (dev-only) across DesignSystemPlayground, Home view, and app root. Add SKILL.md guidance under .agents/skills/agentation and a .claude/skills/agentation pointer for Claude Code MCP configuration. Adjust PendingErrorsIndicator positioning in dev to avoid overlap with the toolbar.